### PR TITLE
Allow user to configure redirecting to https.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ These must be defined in your playbook for this role to work.
 |---|---|---|
 | `rails_app_url_base_path` | "/" | The url path where the application will be served  |
 | `is_blacklight_app` | false | If this is a blacklight app, then it does some Blacklight specific things  |
-| `rails_app_use_ssl` | false   |  Set to true to create ssl virtual hosts and add certificates|
+| `rails_app_use_ssl` | false   |  Set to true to create ssl virtual hosts and add certificates |
+| `rails_app_force_ssl` | false   |  Set to true to redirect all incoming traffic to https |
 |`rails_app_user`   |  {{ rails_app_name }} |  The user that runs the app, under whose account rbenv is installed |
 | `rails_app_git_branch` | master |   |
 | `rails_app_install_path` | /var/www/{{ rails_app_name }} |   |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ rails_app_ruby_path: /home/{{ rails_app_user }}/.rbenv/versions/{{ rbenv.default
 rails_app_bundle_exe: "{{rails_app_ruby_path}}/bin/bundle"
 rails_app_gem_path: "{{rails_app_ruby_path}}/lib/ruby/gems"
 rails_app_url_base_path: "/"
+rails_app_use_ssl: false
+rails_app_force_ssl: false
 
 
 rails_app_default_config: 

--- a/templates/applications.conf.j2
+++ b/templates/applications.conf.j2
@@ -10,6 +10,12 @@ Header always set X-Content-Type-Options nosniff
 <VirtualHost *:80>
     ServerName {{ fqdn| default(ansible_fqdn) }}
 
+    {% if rails_app_force_ssl %}
+    RewriteEngine On
+    RewriteCond %{HTTPS} off
+    RewriteRule (.*) https://%{SERVER_NAME}/$1 [R,L]
+    {% endif %}
+
     # Tell Apache and Passenger where your app's 'public' directory is
     DocumentRoot /var/www/html
     PassengerRuby /usr/bin/ruby


### PR DESCRIPTION
REF BL-225

Adds a new variable to allow user to enabled redirecting all the server
traffic from http to https.

QA Steps
===
* Provision a machine using this role with `rails_app_force_ssl` var set to `true`
- [ ] Verify that redirection rule is added to virtual host for *:80