### PR TITLE
Manage Bundler configs

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -9,6 +9,9 @@
       rails_app_git_url: https://github.com/bibliotechy/rails-nihilist
       rails_app_prod_secret: EXTREMELY_LONG_SECRET_VALUE
       bundler_version: 2.0.1
+      rails_app_bundler_configs:
+        - key: "NEEDS_FLAGS"
+          value: "--with-flags"
   vars:
     rbenv:
       env: user

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,3 +19,9 @@ def test_httpd_application_conf_created(host):
 def test_rails_app_in_place(host):
     app_dir = host.file("/var/www/nothing")
     assert app_dir.is_directory
+
+
+def test_bundle_config_in_place(host):
+    f = host.file("/home/nothing/.bundle/config")
+    assert f.exists
+    assert f.contains("NEEDS_FLAGS: \"--with-flags\"")

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -43,6 +43,28 @@
   tags:
     - rails_app
 
+- name: Ensure the .bundle directory exists
+  file:
+    state: directory
+    dest: "/home/{{ rails_app_user }}/.bundle"
+    owner: "{{ rails_app_user }}"
+    group: "{{ rails_app_user }}"
+  become: true
+  become_user: "{{ rails_app_user }}"
+  tags:
+    - rails_app
+
+- name: Set Bundler config options in ~/.bundle/config
+  template:
+    src: bundler_config.j2
+    dest: "/home/{{ rails_app_user }}/.bundle/config"
+    owner: "{{ rails_app_user }}"
+    group: "{{ rails_app_user }}"
+  become: true
+  become_user: "{{ rails_app_user }}"
+  tags:
+    - rails_app
+
 - name: bundle install the app gems dependencies
   bundler:
     state: present

--- a/templates/bundler_config.j2
+++ b/templates/bundler_config.j2
@@ -1,0 +1,6 @@
+---
+
+{% for config in rails_app_bundler_configs %}
+{{ config.key }}: "{{ config.value }}"
+
+{% endfor %}


### PR DESCRIPTION
Some gems, like pg for potgres, may require extra config flgas that
cannot be added at `bundle install` runtime, but need to be added to a
config file. This pr adds the ability to manage those configs via a variable