### PR TITLE
Use assets:clean instead of assets:clobber

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,7 +20,7 @@
   args:
     chdir: "{{ rails_app_install_path }}"
   with_items:
-    - assets:clobber
+    - assets:clean
     - assets:precompile
     - db:migrate
   become: true


### PR DESCRIPTION
Switching this should allow for smoother transitions in rolling upgrades to avoid short periods where old assets are unavailable. As per the [rails-sprockets docs](https://github.com/rails/sprockets-rails#usage)
rake assets:clean: Only removes old assets (keeps the most recent 3 copies) from public/assets. Useful when doing rolling deploys that may still be serving old assets while the new ones are being compiled.