### PR TITLE
Add .env.local for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These must be defined in your playbook for this role to work.
 | `rails_app_bundle_exe` | "{{rails_app_ruby_path}}/bin/bundle" |   |
 | `rails_app_gem_path` | "{{rails_app_ruby_path}}/lib/ruby/gems" |   |
 | `rails_app_env` | production |   |
+| `rails_app_user_envvars`| [] | Array of dictionaries of evvars to be set. `{envvar: "COW", value: "moo"}`. Can also take an `when` for conditional envvar setting |
 | `rails_app_deployment_exclude_groups`: [test, development] | |
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,18 @@ nodejs_version: 6.17.1
 rails_app_use_webpack: true
 yarn_version: v1.13.0
 
+# Define env vars that will be available to the app via a .env file
+# list items should be an array with two required and one possible value
+# envvar - required - name of the envvar to be set
+# value - required - value of the envvar to be set
+# when - optional - statement that resolves to boolean to decide
+# if the envvar should be set
+# example
+# {envvar: "COW", value: "moo"}
+# {envvar: "COW", value: "moo", when: "{{ set_cow is defined and set_cow }}"}
+rails_app_user_envvars: []
+
+
 rails_app_user: "{{ rails_app_name }}"
 rails_app_git_branch: master
 rails_app_install_path: /var/www/{{ rails_app_name }}

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -12,6 +12,12 @@
       rails_app_bundler_configs:
         - key: "NEEDS_FLAGS"
           value: "--with-flags"
+      set_pig: true
+      rails_app_user_envvars:
+        - {envvar: "MOO", value: "cow"}
+        - {envvar: "COW", value: "moo", when: "{{ set_cow is defined and set_cow }}"}
+        - {envvar: "PIG", value: "oink", when: "{{ set_pig is defined and set_pig }}"}
+
   vars:
     rbenv:
       env: user

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,3 +25,11 @@ def test_bundle_config_in_place(host):
     f = host.file("/home/nothing/.bundle/config")
     assert f.exists
     assert f.contains("NEEDS_FLAGS: \"--with-flags\"")
+
+
+def test_rails_app_user_envvars(host):
+    env = host.file("/var/www/nothing/.env.local")
+    assert env.exists
+    assert env.contains("MOO='cow'")
+    assert env.contains("PIG='oink'")
+    assert env.contains("COW='moo'") is False

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -109,6 +109,15 @@
   tags:
     - rails_app
 
+- name: Create a .env file in the root of the app
+  template:
+    dest: "{{ rails_app_install_path }}/.env.local"
+    src: .env.local.j2
+  notify:
+    - restart passenger app
+  tags:
+    - rails_app
+
 - include: db.yml
   when: using_postgres
 

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -113,6 +113,8 @@
   template:
     dest: "{{ rails_app_install_path }}/.env.local"
     src: .env.local.j2
+  become: true
+  become_user: "{{ rails_app_user }}"
   notify:
     - restart passenger app
   tags:

--- a/templates/.env.local.j2
+++ b/templates/.env.local.j2
@@ -1,0 +1,5 @@
+{% for item in rails_app_user_envvars %}
+{% if (item.when is undefined) or (item.when is defined and item.when) %}
+{{ item.envvar }}='{{ item.value }}'
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Adds a .env.local file into the root of the app, which can be picked by the dotenv gem if bundled into the app.

Now, any env vars that need to be defined for a rails app can be defined as items in the `rails_app_user_envvars` variable.

Items are defined a dictionary with two required fields , envvar
and value, and when, which allows setting conditions for when the variable should be set.