### PR TITLE
Symlink .env.inventory to .env

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 ## dependencies.yml
 # default to no app specific dependencies to install
 rails_app_additional_dependencies: []
+
 nodejs_version: 6.17.1
 rails_app_use_webpack: true
 yarn_version: v1.13.0
@@ -50,3 +51,4 @@ app_use_intermediate_cert: true
 app_set_root_redirect: false
 
 using_postgres: false
+inventory_shortname: "{{ inventory_dir.split('/')[-1] }}"

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -135,6 +135,7 @@
     dest: "{{ rails_app_install_path }}/.env"
   when: inventory_env.stat.exists
   become: true
+  become_user: "{{ rails_app_user }}"
   notify:
     - restart passenger app
   tags:

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -120,6 +120,26 @@
   tags:
     - rails_app
 
+- name: Check if an inventory env file exists in the app
+  stat:
+    path: "{{ rails_app_install_path }}/.env.{{ inventory_shortname }}"
+  register: inventory_env
+  changed_when: false
+  tags:
+    - rails_app
+
+- name: create symlink to inventory env file if it exists
+  file:
+    state: link
+    src: "{{ rails_app_install_path }}/.env.{{ inventory_shortname }}"
+    dest: "{{ rails_app_install_path }}/.env"
+  when: inventory_env.stat.exists
+  become: true
+  notify:
+    - restart passenger app
+  tags:
+    - rails_app
+
 - include: db.yml
   when: using_postgres
 


### PR DESCRIPTION
To handle cases where the app has inventory specific .env files, this
symlinks the .env.(inventory name) to .env in the root of the app, so
dotenv can pick it up along with .env.local