### PR TITLE
Use nodesource to install required node version.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,9 @@
 # default to no app specific dependencies to install
 rails_app_additional_dependencies: []
 
-nodejs_version: 6.17.1
+
+nodejs_major_version: 8
+nodejs_version: 8.16.2
 rails_app_use_webpack: true
 yarn_version: v1.13.0
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -22,6 +22,6 @@
     rbenv:
       env: user
       version: v1.0.0
-      default_ruby: 2.5.1
+      default_ruby: 2.6.5
       rubies:
-        - version: 2.5.1
+        - version: 2.6.5

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -43,8 +43,8 @@
         rbenv:
           env: user
           version: v1.1.1
-          default_ruby: 2.5.1
+          default_ruby: 2.6.5
           rubies:
-            - version: 2.5.1
+            - version: 2.6.5
 
     - role: tulibraries.ansible_role_passenger_apache

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -26,11 +26,34 @@
     - epel-release
   become: true
 
-- name: install nodejs for asset pipeline for rails
+
+- name: Check current node version
+  shell: node --version 2>&1
+  register: installed_node_version
+  failed_when: false  # noqa 301
+  changed_when: false
+
+- name: remove old versions of node
   yum:
-    name: nodejs-{{ nodejs_version }}
+    name: nodejs
+    state: absent
+  when: installed_node_version.stdout is not regex("v{{ nodejs_major_version }}.*")  # noqa 102
+
+- name: Import Nodesource RPM key
+  rpm_key:
+    key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
-  become: true
+
+- name: Add Nodesource repositories for Node.js
+  yum:
+    name: "https://rpm.nodesource.com/pub_{{ nodejs_major_version }}.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"  # noqa 204
+    state: present
+
+- name: Ensure Node.js and npm are installed.
+  yum:
+    name: "nodejs-{{ nodejs_version }}"
+    state: present
+    enablerepo: "nodesource"
 
 - name: Install yarn node package if this project needs it
   npm:


### PR DESCRIPTION
Ensures any previous version of nodejs are removed, even ones not installed from nodesource.

