### PR TITLE
yarn install from lockfile and prod only

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,7 +6,7 @@
   args:
     chdir: "{{ rails_app_install_path }}"  # noqa 305
   with_items:
-    - yarn
+    - "yarn install --frozen-lockfile --prod"
   become: true
   become_user: "{{ rails_app_user }}"
   when: rails_app_use_webpack is defined and rails_app_use_webpack


### PR DESCRIPTION
Update the yarn command to read from the yarn.lock, but not update it
when run.

Update the yarn install command to only build prod dependencies, i.e not
the ones in the devDependencies group.