### PR TITLE
DEVO-95 Apache best practices

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,4 +54,4 @@ app_set_root_redirect: false
 using_postgres: false
 inventory_shortname: "{{ inventory_dir.split('/')[-1] }}"
 httpd_status_enable: false
-mpm_event_module: false
+mpm_module: event

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,3 +54,4 @@ app_set_root_redirect: false
 using_postgres: false
 inventory_shortname: "{{ inventory_dir.split('/')[-1] }}"
 httpd_status_enable: false
+mpm_event_module: false

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -19,7 +19,7 @@
         - {envvar: "COW", value: "moo", when: "{{ set_cow is defined and set_cow }}"}
         - {envvar: "PIG", value: "oink", when: "{{ set_pig is defined and set_pig }}"}
       httpd_status_enable: true
-      mpm_event_module: true
+      mpm_module: event
   vars:
     rbenv:
       env: user

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -19,6 +19,7 @@
         - {envvar: "COW", value: "moo", when: "{{ set_cow is defined and set_cow }}"}
         - {envvar: "PIG", value: "oink", when: "{{ set_pig is defined and set_pig }}"}
       httpd_status_enable: true
+      mpm_event_module: true
   vars:
     rbenv:
       env: user

--- a/tasks/passenger-config.yml
+++ b/tasks/passenger-config.yml
@@ -37,6 +37,7 @@
   template:
     src: mpm_module.conf.j2
     dest: /etc/httpd/conf.modules.d/00-mpm.conf
+  when: mpm_event_module
   become: true
   notify: restart apache
   tags:

--- a/tasks/passenger-config.yml
+++ b/tasks/passenger-config.yml
@@ -33,6 +33,16 @@
     - rails_app
     - passenger
 
+- name: Write MPM module to use event
+  template:
+    src: mpm_module.conf.j2
+    dest: /etc/httpd/conf.modules.d/00-mpm.conf
+  become: true
+  notify: restart apache
+  tags:
+    - rails_app
+    - passenger
+
 - name: Put the applications specific template in place
   template:
     src: conf-fragment.j2

--- a/tasks/passenger-config.yml
+++ b/tasks/passenger-config.yml
@@ -37,7 +37,6 @@
   template:
     src: mpm_module.conf.j2
     dest: /etc/httpd/conf.modules.d/00-mpm.conf
-  when: mpm_event_module
   become: true
   notify: restart apache
   tags:

--- a/templates/mpm_module.conf.j2
+++ b/templates/mpm_module.conf.j2
@@ -3,14 +3,27 @@
 
 # prefork MPM: Implements a non-threaded, pre-forking web server
 # See: http://httpd.apache.org/docs/2.4/mod/prefork.html
-# LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+{% if mpm_module == "prefork" %}
+LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+{% else %}
+#LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+{% endif %}
 
 # worker MPM: Multi-Processing Module implementing a hybrid
 # multi-threaded multi-process web server
 # See: http://httpd.apache.org/docs/2.4/mod/worker.html
-# LoadModule mpm_worker_module modules/mod_mpm_worker.so
+{% if mpm_module == "worker" %}
+LoadModule mpm_worker_module modules/mod_mpm_worker.so
+{% else %}
+#LoadModule mpm_worker_module modules/mod_mpm_worker.so
+{% endif %}
 
 # event MPM: A variant of the worker MPM with the goal of consuming
 # threads only for connections with active processing
 # See: http://httpd.apache.org/docs/2.4/mod/event.html
+
+{% if mpm_module == "event" %}
 LoadModule mpm_event_module modules/mod_mpm_event.so
+{% else %}
+#LoadModule mpm_event_module modules/mod_mpm_event.so
+{% endif %}

--- a/templates/mpm_module.conf.j2
+++ b/templates/mpm_module.conf.j2
@@ -1,0 +1,16 @@
+# Select the MPM module which should be used by uncommenting exactly
+# one of the following LoadModule lines:
+
+# prefork MPM: Implements a non-threaded, pre-forking web server
+# See: http://httpd.apache.org/docs/2.4/mod/prefork.html
+# LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+
+# worker MPM: Multi-Processing Module implementing a hybrid
+# multi-threaded multi-process web server
+# See: http://httpd.apache.org/docs/2.4/mod/worker.html
+# LoadModule mpm_worker_module modules/mod_mpm_worker.so
+
+# event MPM: A variant of the worker MPM with the goal of consuming
+# threads only for connections with active processing
+# See: http://httpd.apache.org/docs/2.4/mod/event.html
+LoadModule mpm_event_module modules/mod_mpm_event.so


### PR DESCRIPTION
- We have been using the default prefork MOM, but that is not recommended.
- Updates apache to use the event MPM (best for performance)