### PR TITLE
DEVO-84 Rake to rails

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,7 +16,7 @@
 
 - name: deploy tasks
   command: >
-    bash -lc 'RAILS_ENV={{ rails_app_env }} bundle exec rake {{ item }}'
+    bash -lc 'RAILS_ENV={{ rails_app_env }} bundle exec rails {{ item }}'
   args:
     chdir: "{{ rails_app_install_path }}"
   with_items:
@@ -32,7 +32,7 @@
 
 - name: migrate db
   command: >
-    bash -lc 'RAILS_ENV={{ rails_app_env }} bundle exec rake {{ item }}'
+    bash -lc 'RAILS_ENV={{ rails_app_env }} bundle exec rails {{ item }}'
   args:
     chdir: "{{ rails_app_install_path }}"
   with_items:


### PR DESCRIPTION
- We have had some problems with deploys in the past due to using the rake command.  This updates the handlers to use the rails command instead.