### PR TITLE
Devo 79 add logrotate

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,6 +5,11 @@
   vars:
     rails_app_user: nothing
   pre_tasks:
+    - name: Add software collections
+      yum:
+        name:
+          - centos-release-scl-rh
+        state: present
     - name: install library dependencies
       package:
         name: "{{ item }}"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,11 +5,6 @@
   vars:
     rails_app_user: nothing
   pre_tasks:
-    - name: Add software collections
-      yum:
-        name:
-          - centos-release-scl-rh
-        state: present
     - name: install library dependencies
       package:
         name: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,3 +6,4 @@
 - include: passenger-config.yml
   when: is_webserver
 - include: install-app.yml
+- include: manage_configuration.yml

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -10,10 +10,10 @@
   tags:
     - logging
 
-- name: ensure logrotate is in /etc/cron.weekly
+- name: ensure logrotate is in /etc/cron.daily
   file:
     src: /etc/cron.daily/logrotate
-    dest: /etc/cron.weekly/logrotate
+    dest: /etc/cron.daily/logrotate
     state: link
     force: true
     mode: 0755  # the file needs to be excutable

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -13,7 +13,7 @@
 - name: ensure logrotate is in /etc/cron.daily
   file:
     src: /etc/cron.daily/logrotate
-    dest: /etc/cron.daily/logrotate
+    dest: /etc/cron.hourly/logrotate
     state: link
     force: true
     mode: 0755  # the file needs to be excutable

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -9,13 +9,3 @@
     group: "root"
   tags:
     - logging
-
-- name: ensure logrotate is in /etc/cron.daily
-  file:
-    src: /etc/cron.daily/logrotate
-    dest: /etc/cron.hourly/logrotate
-    state: link
-    force: true
-    mode: 0755  # the file needs to be excutable
-  tags:
-    - logging

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -1,0 +1,21 @@
+---
+
+- name: "CONFIG | Manage logrotate configuration"
+  template:
+    src: templates/logrotate.j2
+    dest: "/etc/logrotate.d/rails"
+    mode: 0644
+    owner: "root"
+    group: "root"
+  tags:
+    - logging
+
+- name: ensure logrotate is in /etc/cron.weekly
+  file:
+    src: /etc/cron.daily/logrotate
+    dest: /etc/cron.weekly/logrotate
+    state: link
+    force: yes
+    mode: 0755 # the file needs to be excutable
+  tags:
+    - logging

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -15,7 +15,7 @@
     src: /etc/cron.daily/logrotate
     dest: /etc/cron.weekly/logrotate
     state: link
-    force: yes
-    mode: 0755 # the file needs to be excutable
+    force: true
+    mode: 0755  # the file needs to be excutable
   tags:
     - logging

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,0 +1,9 @@
+/path/to/your/rails/log/.log {
+    size 50M              # triggers when file is bigger than 50M
+    dateext               # use date extension
+    dateformat -%Y%m%d-%s # the extention format
+    rotate 10             # keep 10 files
+    copytruncate          # truncates the original file
+    missingok             # does not throw error if the file is missing
+    notifempty            # does not rotate if the file is empty
+}

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,11 +1,11 @@
 /var/www/{{ rails_app_name }}/log/production.log
 /var/log/httpd/*.log
 {
-    size 50M              # triggers when file is bigger than 50M
-    dateext               # use date extension
-    dateformat -%Y%m%d-%s # the extention format
-    rotate 10             # keep 10 files
-    copytruncate          # truncates the original file
-    missingok             # does not throw error if the file is missing
-    notifempty            # does not rotate if the file is empty
+    maxsize 50M
+    dateext
+    dateformat -%Y%m%d-%s
+    rotate 10
+    copytruncate
+    missingok
+    notifempty
 }

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,4 +1,4 @@
-/var/www/"{{ rails_app_name }}"/log/production.log {
+/var/www/{{ rails_app_name }}/log/production.log {
     size 50M              # triggers when file is bigger than 50M
     dateext               # use date extension
     dateformat -%Y%m%d-%s # the extention format

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,5 +1,6 @@
 /var/www/{{ rails_app_name }}/log/production.log
-/var/log/httpd/*.log
+/var/log/httpd/access_log
+/var/log/httpd/error_log
 {
     maxsize 50M
     dateext

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,4 +1,6 @@
-/var/www/{{ rails_app_name }}/log/production.log {
+/var/www/{{ rails_app_name }}/log/production.log
+/var/log/httpd/*.log
+{
     size 50M              # triggers when file is bigger than 50M
     dateext               # use date extension
     dateformat -%Y%m%d-%s # the extention format

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -2,6 +2,7 @@
 /var/log/httpd/access_log
 /var/log/httpd/error_log
 {
+    daily
     maxsize 50M
     dateext
     dateformat -%Y%m%d-%s

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -2,7 +2,7 @@
 /var/log/httpd/access_log
 /var/log/httpd/error_log
 {
-    daily
+    weekly
     maxsize 50M
     dateext
     dateformat -%Y%m%d-%s

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,4 +1,4 @@
-/path/to/your/rails/log/.log {
+/var/www/"{{ rails_app_name }}"/log/production.log {
     size 50M              # triggers when file is bigger than 50M
     dateext               # use date extension
     dateformat -%Y%m%d-%s # the extention format


### PR DESCRIPTION
- Configures log rotate to rotate weekly or when files size reaches 50mb
- Applies to production, access, and error logs