### PR TITLE
Fix deprecated bundle flags

### DIFF
--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -69,7 +69,6 @@
   bundler:
     state: present
     chdir: "{{ rails_app_install_path }}"
-    deployment_mode: true
     exclude_groups: "{{ rails_app_deployment_exclude_groups }}"
     executable: "{{ rails_app_bundle_exe }}"
   become: true

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -69,7 +69,6 @@
   bundler:
     state: present
     chdir: "{{ rails_app_install_path }}"
-    exclude_groups: "{{ rails_app_deployment_exclude_groups }}"
     executable: "{{ rails_app_bundle_exe }}"
   become: true
   become_user: "{{ rails_app_user }}"


### PR DESCRIPTION
In Bundler, deploy and exclude environment flags have been deprecated.  Ansible indicates bundler error:
`/home/gencon50/.rbenv/versions/2.7.2/bin/bundle install --without test:development --deployment", "msg": "[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment 'true'`, and stop using this flag
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'test:development'`, and stop using this flag
Your Gemfile lists the gem pry (>= 0) more than once.`