### PR TITLE
Remove deprecated deployment flag and without option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These must be defined in your playbook for this role to work.
 | `rails_app_gem_path` | "{{rails_app_ruby_path}}/lib/ruby/gems" |   |
 | `rails_app_env` | production |   |
 | `rails_app_user_envvars`| [] | Array of dictionaries of evvars to be set. `{envvar: "COW", value: "moo"}`. Can also take an `when` for conditional envvar setting |
-| `rails_app_deployment_exclude_groups`: [test, development] | |
+| `rails_app_deployment_exclude_groups`: "test development" | A space-separated list of groups referencing gems to skip during installation |
 
 
 

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,5 +1,11 @@
 ---
 
+- pre_tasks:
+  - name: Update ca-certificates
+    package:
+      name: ca-certificates
+      state: latest
+
 - name: Install rails dependencies
   yum:
     name: ["git-core",

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,11 +1,5 @@
 ---
 
-- pre_tasks:
-  - name: Update ca-certificates
-    package:
-      name: ca-certificates
-      state: latest
-
 - name: Install rails dependencies
   yum:
     name: ["git-core",

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -69,8 +69,6 @@
   bundler:
     state: present
     chdir: "{{ rails_app_install_path }}"
-    deployment_mode: true
-    exclude_groups: "{{ rails_app_deployment_exclude_groups }}"
     executable: "{{ rails_app_bundle_exe }}"
   become: true
   become_user: "{{ rails_app_user }}"


### PR DESCRIPTION
- If still used, these can be placed in rails_app_bundler_config in the application's
playbook